### PR TITLE
Migrate books topics to path segments

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,29 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  cacheLife: {
+    cms: {
+      stale: 300,
+      revalidate: 60 * 60 * 3,
+      expire: 60 * 60 * 24,
+    },
+  },
+  async redirects() {
+    return [
+      {
+        source: "/books",
+        has: [
+          {
+            type: "query",
+            key: "topic",
+            value: "(?<topic>.*)",
+          },
+        ],
+        destination: "/books/topic/:topic",
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/src/app/books/[id]/loading.tsx
+++ b/src/app/books/[id]/loading.tsx
@@ -1,9 +1,0 @@
-import { Spinner } from "@/components/ui/spinner";
-
-export default function BookDetailLoading() {
-  return (
-    <div className="max-w-3xl mx-auto px-4 py-8 flex items-center justify-center min-h-[400px]">
-      <Spinner className="size-6" />
-    </div>
-  );
-}

--- a/src/app/books/layout.tsx
+++ b/src/app/books/layout.tsx
@@ -1,34 +1,43 @@
-import { Suspense } from "react";
-import { ErrorBoundary } from "@/components/layouts/ErrorBoundary";
 import { SideMenu } from "@/components/ui/SideMenu";
-import { Spinner } from "@/components/ui/spinner";
 import { TopicFilter } from "@/modules/books/ui/view/TopicFilter";
 import { getAllTopics } from "@/modules/notion/service/api";
 
-async function TopicFilterSection() {
-  const topics = await getAllTopics();
-  return <TopicFilter topics={topics} />;
+type TopicFilterSectionProps = {
+  activeTopic?: string;
+};
+
+async function TopicFilterSection({ activeTopic }: TopicFilterSectionProps) {
+  try {
+    const topics = await getAllTopics();
+    return <TopicFilter topics={topics} activeTopic={activeTopic} />;
+  } catch {
+    return (
+      <p className="px-2 py-1 text-sm text-gray-500">
+        トピックを読み込めませんでした。
+      </p>
+    );
+  }
 }
 
-export default function BooksLayout({
-  children,
-}: {
+type BooksLayoutProps = {
   children: React.ReactNode;
-}) {
+  params: Promise<{
+    id?: string;
+    topic?: string;
+  }>;
+};
+
+export default async function BooksLayout({
+  children,
+  params,
+}: BooksLayoutProps) {
+  const { topic } = await params;
+  const activeTopic = topic ? decodeURIComponent(topic) : undefined;
+
   return (
     <div className="flex">
       <SideMenu title="Topics" isInner>
-        <ErrorBoundary>
-          <Suspense
-            fallback={
-              <div className="flex justify-center p-4">
-                <Spinner className="size-5" />
-              </div>
-            }
-          >
-            <TopicFilterSection />
-          </Suspense>
-        </ErrorBoundary>
+        <TopicFilterSection activeTopic={activeTopic} />
       </SideMenu>
 
       <div className="flex-1">{children}</div>

--- a/src/app/books/loading.tsx
+++ b/src/app/books/loading.tsx
@@ -1,9 +1,0 @@
-import { Spinner } from "@/components/ui/spinner";
-
-export default function BooksLoading() {
-  return (
-    <div className="flex items-center justify-center py-12">
-      <Spinner className="size-6" />
-    </div>
-  );
-}

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,17 +1,9 @@
 import { ReadingNoteListSection } from "@/modules/books/ui/section/ReadingNoteListSection";
 
-interface BooksPageProps {
-  searchParams: Promise<{
-    topic?: string;
-  }>;
-}
-
-export default async function BooksPage({ searchParams }: BooksPageProps) {
-  const { topic } = await searchParams;
-
+export default function BooksPage() {
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
-      <ReadingNoteListSection topic={topic} />
+      <ReadingNoteListSection />
     </div>
   );
 }

--- a/src/app/books/topic/[topic]/page.tsx
+++ b/src/app/books/topic/[topic]/page.tsx
@@ -1,0 +1,23 @@
+import type { BookTopicParams } from "@/lib/routes";
+import { ReadingNoteListSection } from "@/modules/books/ui/section/ReadingNoteListSection";
+import { getAllTopics } from "@/modules/notion/service/api";
+
+type Props = {
+  params: Promise<BookTopicParams>;
+};
+
+export async function generateStaticParams() {
+  const topics = await getAllTopics();
+  return topics.map((topic) => ({ topic }));
+}
+
+export default async function BooksTopicPage({ params }: Props) {
+  const { topic } = await params;
+  const decodedTopic = decodeURIComponent(topic);
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <ReadingNoteListSection topic={decodedTopic} />
+    </div>
+  );
+}

--- a/src/components/ui/SideMenu.tsx
+++ b/src/components/ui/SideMenu.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { type FC, type ReactNode, useMemo } from "react";
+import type { FC, ReactNode } from "react";
 import { ScrollArea } from "@/components/layouts/ScrollArea";
 import { cn } from "@/lib/utils";
 
@@ -16,32 +14,23 @@ export const SideMenu: FC<SideMenuProps> = ({
   isInner,
   children,
   className,
-}) => {
-  const memoizedScrollArea = useMemo(
-    () => (
-      <ScrollArea
-        className={cn(
-          "hidden bg-zinc-50 lg:flex lg:flex-col lg:border-r",
-          "lg:h-screen lg:sticky lg:top-0",
-          isInner ? "lg:w-80 xl:w-96" : "lg:w-60 xl:w-72",
-          className,
-        )}
-      >
-        {title && (
-          <div className="sticky top-0 z-10 border-b bg-zinc-50 px-5 py-3">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-semibold tracking-tight">
-                {title}
-              </span>
-              <div className="flex items-center gap-2"></div>
-            </div>
-          </div>
-        )}
-        <div className="bg-zinc-50 p-3 flex-1 overflow-y-auto">{children}</div>
-      </ScrollArea>
-    ),
-    [isInner, title, children, className],
-  );
-
-  return memoizedScrollArea;
-};
+}) => (
+  <ScrollArea
+    className={cn(
+      "hidden bg-zinc-50 lg:flex lg:flex-col lg:border-r",
+      "lg:h-screen lg:sticky lg:top-0",
+      isInner ? "lg:w-80 xl:w-96" : "lg:w-60 xl:w-72",
+      className,
+    )}
+  >
+    {title && (
+      <div className="sticky top-0 z-10 border-b bg-zinc-50 px-5 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold tracking-tight">{title}</span>
+          <div className="flex items-center gap-2"></div>
+        </div>
+      </div>
+    )}
+    <div className="bg-zinc-50 p-3 flex-1 overflow-y-auto">{children}</div>
+  </ScrollArea>
+);

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -7,6 +7,7 @@
  *
  * routes.home()                      // "/"
  * routes.books.index()               // "/books"
+ * routes.books.topic("react")        // "/books/topic/react"
  * routes.books.detail("abc123")      // "/books/abc123"
  * routes.posts.year(2024)            // "/posts/2024"
  * routes.posts.detail(2024, "id")    // "/posts/2024/id"
@@ -31,13 +32,16 @@ export const routes = {
   books: {
     /**
      * 読書メモ一覧ページへのルート
-     * @param topic - フィルタリングするトピック（オプション）
      * @returns 読書メモ一覧のパス
      */
-    index: (topic?: string) => {
-      const base = "/books";
-      return topic ? `${base}?topic=${encodeURIComponent(topic)}` : base;
-    },
+    index: () => "/books" as const,
+    /**
+     * トピック別の読書メモ一覧ページへのルート
+     * @param topic - フィルタリングするトピック
+     * @returns トピック別読書メモ一覧のパス
+     */
+    topic: (topic: string) =>
+      `/books/topic/${encodeURIComponent(topic)}` as const,
     /**
      * 読書メモ詳細ページへのルート
      * @param id - 読書メモのID
@@ -82,4 +86,12 @@ export type PostDetailParams = {
   year: string;
   /** 投稿ID */
   id: string;
+};
+
+/**
+ * 読書メモトピックページのパラメータ型
+ */
+export type BookTopicParams = {
+  /** トピック */
+  topic: string;
 };

--- a/src/modules/books/ui/view/ReadingNoteDetailView.tsx
+++ b/src/modules/books/ui/view/ReadingNoteDetailView.tsx
@@ -30,7 +30,7 @@ export function ReadingNoteDetailView({ note }: ReadingNoteDetailViewProps) {
                 {note.topics.map((topic) => (
                   <Link
                     key={topic}
-                    href={routes.books.index(topic)}
+                    href={routes.books.topic(topic)}
                     className="text-sm bg-gray-100 text-gray-700 px-3 py-1 rounded-full hover:bg-gray-200 transition-colors"
                   >
                     {topic}

--- a/src/modules/books/ui/view/TopicFilter.tsx
+++ b/src/modules/books/ui/view/TopicFilter.tsx
@@ -1,31 +1,22 @@
-"use client";
-
 import { TagIcon } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
 import { routes } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
 interface TopicFilterProps {
   topics: string[];
+  activeTopic?: string;
 }
 
-export function TopicFilter({ topics }: TopicFilterProps) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const currentTopic = searchParams.get("topic");
-
-  // パスが/booksでない場合は、アクティブ判定しない
-  const isOnBooksPage = pathname === "/books";
-
+export function TopicFilter({ topics, activeTopic }: TopicFilterProps) {
   return (
     <div className="flex flex-col gap-1">
       {topics.map((topic) => {
-        const isActive = isOnBooksPage && currentTopic === topic;
+        const isActive = activeTopic === topic;
         return (
           <Link
             key={topic}
-            href={routes.books.index(topic)}
+            href={routes.books.topic(topic)}
             className={cn(
               "group flex items-center justify-between rounded-lg p-2",
               isActive ? "bg-primary text-white" : "hover:bg-gray-200",

--- a/src/modules/books/ui/view/__tests__/TopicFilter.test.tsx
+++ b/src/modules/books/ui/view/__tests__/TopicFilter.test.tsx
@@ -1,21 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import type { ReadonlyURLSearchParams } from "next/navigation";
-import { usePathname, useSearchParams } from "next/navigation";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { TopicFilter } from "../TopicFilter";
 
-// next/navigationのモック
-vi.mock("next/navigation");
-
 describe("TopicFilter", () => {
-  beforeEach(() => {
-    // デフォルトのパスを設定
-    vi.mocked(usePathname).mockReturnValue("/books");
-    // デフォルトのSearchParamsを設定（トピックなし）
-    vi.mocked(useSearchParams).mockReturnValue({
-      get: vi.fn().mockReturnValue(null),
-    } as unknown as ReadonlyURLSearchParams);
-  });
   it("トピック一覧が表示される（Allは表示されない）", () => {
     const topics = ["プログラミング", "技術書", "ビジネス"];
 
@@ -51,19 +38,14 @@ describe("TopicFilter", () => {
 
     expect(topicLink).toHaveAttribute(
       "href",
-      "/books?topic=%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%9F%E3%83%B3%E3%82%B0",
+      "/books/topic/%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%9F%E3%83%B3%E3%82%B0",
     );
   });
 
   it("選択中のトピックがアクティブ状態で表示される", () => {
-    vi.mocked(usePathname).mockReturnValue("/books");
-    vi.mocked(useSearchParams).mockReturnValue({
-      get: vi.fn().mockReturnValue("プログラミング"),
-    } as unknown as ReadonlyURLSearchParams);
-
     const topics = ["プログラミング", "技術書"];
 
-    render(<TopicFilter topics={topics} />);
+    render(<TopicFilter topics={topics} activeTopic="プログラミング" />);
 
     const programmingLink = screen.getByText("プログラミング").closest("a");
     const techBookLink = screen.getByText("技術書").closest("a");
@@ -73,8 +55,6 @@ describe("TopicFilter", () => {
   });
 
   it("トピックが選択されていない場合はどのトピックもアクティブでない", () => {
-    vi.mocked(usePathname).mockReturnValue("/books");
-
     const topics = ["プログラミング"];
 
     render(<TopicFilter topics={topics} />);

--- a/src/modules/notion/service/api.ts
+++ b/src/modules/notion/service/api.ts
@@ -28,7 +28,7 @@ import type { Block, Post } from "../types";
 export async function getPosts(): Promise<Omit<Post, "blocks">[]> {
   "use cache";
   cacheTag("posts", "posts-all");
-  cacheLife("hours");
+  cacheLife("cms");
 
   const response = await notion.dataSources.query({
     data_source_id: dataSourceId,
@@ -59,7 +59,7 @@ export async function getPosts(): Promise<Omit<Post, "blocks">[]> {
 export async function getPost(id: string): Promise<Post | null> {
   "use cache";
   cacheTag("posts", `posts-${id}`);
-  cacheLife("days");
+  cacheLife("cms");
 
   try {
     const page = await notion.pages.retrieve({ page_id: id });
@@ -99,7 +99,7 @@ export async function getPostsByYear(
 ): Promise<Omit<Post, "blocks">[]> {
   "use cache";
   cacheTag("posts", `posts-${year}`);
-  cacheLife("hours");
+  cacheLife("cms");
 
   const response = await notion.dataSources.query({
     data_source_id: dataSourceId,
@@ -166,7 +166,7 @@ export async function getReadingNotes(options?: {
 }): Promise<ReadingNoteForListView[]> {
   "use cache";
   cacheTag("reading-notes", "reading-notes-all");
-  cacheLife("hours");
+  cacheLife("cms");
 
   const response = await notion.dataSources.query({
     data_source_id: env.NOTION_READING_NOTES_DATABASE_ID,
@@ -197,7 +197,7 @@ export async function getReadingNotes(options?: {
 export async function getReadingNote(id: string): Promise<ReadingNote | null> {
   "use cache";
   cacheTag("reading-notes", `reading-note-${id}`);
-  cacheLife("days");
+  cacheLife("cms");
 
   try {
     const [page, blocksResponse] = await Promise.all([
@@ -233,7 +233,7 @@ export async function getReadingNote(id: string): Promise<ReadingNote | null> {
 export async function getAllTopics(): Promise<string[]> {
   "use cache";
   cacheTag("reading-notes", "reading-notes-topics");
-  cacheLife("hours");
+  cacheLife("cms");
 
   const notes = await getReadingNotes();
   const topicsSet = new Set<string>();


### PR DESCRIPTION
## Summary
- migrate books topic filtering from query params to path segments
- add a topic route and redirect old /books?topic=... URLs
- align Notion cache revalidation to 3 hours and simplify books sidebar rendering

## Testing
- npm run typecheck
- npm run lint
- npx vitest run
- npm run build