### PR TITLE
update: レスポンシブ対応とレイアウト改善

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,9 +12,23 @@
       "Bash(test:*)",
       "Bash(npm install:*)",
       "Bash(npm run test:*)",
-      "Bash(wc:*)"
+      "Bash(wc:*)",
+      "Bash(git add:*)",
+      "Bash(git push:*)",
+      "mcp__chrome-devtools__list_pages",
+      "mcp__chrome-devtools__navigate_page",
+      "mcp__chrome-devtools__take_screenshot",
+      "Bash(git commit:*)",
+      "Bash(find /Users/kokiyamaguchi/Documents/projects/git/personal/github.com/YamaguchiKoki/diary/src -type f \\\\\\( -name \"*.ts\" -o -name \"*.tsx\" \\\\\\) -exec wc -l {} +)",
+      "Bash(npm run:*)",
+      "mcp__chrome-devtools__emulate"
     ]
   },
+  "enabledMcpjsonServers": [
+    "chrome-devtools",
+    "context7",
+    "playwright"
+  ],
   "hooks": {
     "PostToolUse": [
       {
@@ -35,6 +49,5 @@
         ]
       }
     ]
-  },
-  "enabledMcpjsonServers": ["chrome-devtools", "context7", "playwright"]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -685,6 +686,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -708,6 +710,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3508,7 +3511,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3518,8 +3520,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
@@ -3600,8 +3601,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3686,6 +3686,7 @@
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3696,6 +3697,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3706,6 +3708,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3978,6 +3981,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4024,6 +4028,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4306,7 +4311,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4998,6 +5002,7 @@
       "integrity": "sha512-UDS2NayCvmXSXVP6mpTj+73JnNQadZlr9N68189xib2tx5Mls7swlTNao26IoHv46BZJFvXygyRtyXd1feAk1A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5557,7 +5562,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5717,6 +5721,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -5788,6 +5793,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.0.tgz",
       "integrity": "sha512-Y+KbmDbefYtHDDQKLNrmzE/YYzG2msqo2VXhzh5yrJ54tx/6TmGdkR5+kP9ma7i7LwZpZMfoY3m/AoPPPKxtVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.0",
         "@swc/helpers": "0.5.15",
@@ -6046,7 +6052,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6062,7 +6067,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6126,6 +6130,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6135,6 +6140,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6166,8 +6172,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6787,6 +6792,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6916,6 +6922,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7269,6 +7276,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/books/[id]/page.tsx
+++ b/src/app/books/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { ScrollArea } from "@/components/layouts/ScrollArea";
+import { routes } from "@/lib/routes";
 import { ReadingNoteDetailSection } from "@/modules/books/ui/section/ReadingNoteDetailSection";
 import { getReadingNotes } from "@/modules/notion/service/api";
 
@@ -17,5 +19,9 @@ export async function generateStaticParams() {
 export default async function BookDetailPage({ params }: BookDetailPageProps) {
   const { id } = await params;
 
-  return <ReadingNoteDetailSection noteId={id} />;
+  return (
+    <ScrollArea className="bg-white h-screen overflow-y-auto" useScrollAreaId>
+      <ReadingNoteDetailSection noteId={id} goBackLink={routes.books.index()} />
+    </ScrollArea>
+  );
 }

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,9 +1,17 @@
-import { ReadingNoteListSection } from "@/modules/books/ui/section/ReadingNoteListSection";
+import { ScrollArea } from "@/components/layouts/ScrollArea";
+import { FloatingHeader } from "@/components/ui/FloatingHeader";
+import { TopicFilter } from "@/modules/books/ui/view/TopicFilter";
+import { getAllTopics } from "@/modules/notion/service/api";
 
-export default function BooksPage() {
+export default async function BooksPage() {
+  const topics = await getAllTopics();
+
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
-      <ReadingNoteListSection />
-    </div>
+    <ScrollArea className="bg-white h-screen overflow-x-hidden overflow-y-auto">
+      <FloatingHeader title="読書メモ" />
+      <div className="px-4 py-4 lg:hidden">
+        <TopicFilter topics={topics} />
+      </div>
+    </ScrollArea>
   );
 }

--- a/src/app/books/topic/[topic]/page.tsx
+++ b/src/app/books/topic/[topic]/page.tsx
@@ -1,3 +1,5 @@
+import { ScrollArea } from "@/components/layouts/ScrollArea";
+import { FloatingHeader } from "@/components/ui/FloatingHeader";
 import type { BookTopicParams } from "@/lib/routes";
 import { ReadingNoteListSection } from "@/modules/books/ui/section/ReadingNoteListSection";
 import { getAllTopics } from "@/modules/notion/service/api";
@@ -14,10 +16,14 @@ export async function generateStaticParams() {
 export default async function BooksTopicPage({ params }: Props) {
   const { topic } = await params;
   const decodedTopic = decodeURIComponent(topic);
+  const title = decodedTopic;
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
-      <ReadingNoteListSection topic={decodedTopic} />
-    </div>
+    <ScrollArea className="bg-white h-screen overflow-x-hidden overflow-y-auto">
+      <FloatingHeader title={title} />
+      <div className="py-4 lg:max-w-4xl lg:mx-auto lg:px-4">
+        <ReadingNoteListSection topic={decodedTopic} />
+      </div>
+    </ScrollArea>
   );
 }

--- a/src/app/posts/[year]/page.tsx
+++ b/src/app/posts/[year]/page.tsx
@@ -13,7 +13,9 @@ export default async function YearPage({ params }: Props) {
   return (
     <ScrollArea className="lg:hidden">
       <FloatingHeader title={`${year}年の日記`} />
-      <PostListSection year={year} isMobile />
+      <div className="py-4">
+        <PostListSection year={year} isMobile />
+      </div>
     </ScrollArea>
   );
 }

--- a/src/modules/books/ui/section/ReadingNoteDetailSection.tsx
+++ b/src/modules/books/ui/section/ReadingNoteDetailSection.tsx
@@ -1,13 +1,16 @@
 import { notFound } from "next/navigation";
+import { ReadingNoteDetailHeader } from "@/modules/books/ui/view/ReadingNoteDetailHeader";
 import { ReadingNoteDetailView } from "@/modules/books/ui/view/ReadingNoteDetailView";
 import { getReadingNote } from "@/modules/notion/service/api";
 
 export type ReadingNoteDetailSectionProps = {
   noteId: string;
+  goBackLink: string;
 };
 
 export async function ReadingNoteDetailSection({
   noteId,
+  goBackLink,
 }: ReadingNoteDetailSectionProps) {
   const note = await getReadingNote(noteId);
 
@@ -15,5 +18,10 @@ export async function ReadingNoteDetailSection({
     notFound();
   }
 
-  return <ReadingNoteDetailView note={note} />;
+  return (
+    <>
+      <ReadingNoteDetailHeader title={note.title} goBackLink={goBackLink} />
+      <ReadingNoteDetailView note={note} />
+    </>
+  );
 }

--- a/src/modules/books/ui/section/ReadingNoteListSection.tsx
+++ b/src/modules/books/ui/section/ReadingNoteListSection.tsx
@@ -14,10 +14,11 @@ export async function ReadingNoteListSection({
   return (
     <>
       <PageTitle
-        title={topic ? `読書メモ: ${topic}` : "読書メモ"}
+        title={topic ?? "読書メモ"}
         subtitle={
           <p className="text-gray-600 mt-2">{notes.length}件の読書メモ</p>
         }
+        className="px-4 lg:px-0"
       />
       <ReadingNoteListView notes={notes} />
     </>

--- a/src/modules/books/ui/view/ReadingNoteDetailHeader.tsx
+++ b/src/modules/books/ui/view/ReadingNoteDetailHeader.tsx
@@ -1,0 +1,14 @@
+import type { FC } from "react";
+import { FloatingHeader } from "@/components/ui/FloatingHeader";
+
+type ReadingNoteDetailHeaderProps = {
+  title: string;
+  goBackLink: string;
+};
+
+export const ReadingNoteDetailHeader: FC<ReadingNoteDetailHeaderProps> = ({
+  title,
+  goBackLink,
+}) => {
+  return <FloatingHeader scrollTitle={title} goBackLink={goBackLink} />;
+};

--- a/src/modules/books/ui/view/ReadingNoteListItem.tsx
+++ b/src/modules/books/ui/view/ReadingNoteListItem.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { routes } from "@/lib/routes";
+import { cn } from "@/lib/utils";
 import type { ReadingNoteForListView } from "@/modules/books/types";
 
 interface ReadingNoteListItemProps {
@@ -10,10 +11,13 @@ export function ReadingNoteListItem({ note }: ReadingNoteListItemProps) {
   return (
     <Link
       href={routes.books.detail(note.id)}
-      className="group flex flex-col justify-between gap-4 rounded-xl bg-gray-50 p-5 transition-all duration-200 hover:bg-gray-100"
+      className={cn(
+        "group flex min-w-0 flex-col justify-between gap-2 border-b px-4 py-3 transition-colors duration-200 hover:bg-gray-100",
+        "lg:gap-4 lg:rounded-xl lg:border-b-0 lg:bg-gray-50 lg:p-5",
+      )}
     >
-      <div className="flex flex-col gap-2">
-        <h3 className="font-semibold text-base leading-snug group-hover:text-primary transition-colors duration-200">
+      <div className="flex min-w-0 flex-col gap-2">
+        <h3 className="break-words font-semibold text-base leading-snug transition-colors duration-200 group-hover:text-primary">
           {note.title}
         </h3>
 
@@ -29,11 +33,11 @@ export function ReadingNoteListItem({ note }: ReadingNoteListItemProps) {
       </div>
 
       {note.topics.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex min-w-0 flex-wrap gap-1.5">
           {note.topics.map((topic) => (
             <span
               key={topic}
-              className="text-xs border border-gray-200 text-gray-500 px-2 py-0.5 rounded-full"
+              className="max-w-full break-all rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500"
             >
               {topic}
             </span>

--- a/src/modules/books/ui/view/ReadingNoteListView.tsx
+++ b/src/modules/books/ui/view/ReadingNoteListView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import type { ReadingNoteForListView } from "@/modules/books/types";
 import { ReadingNoteListItem } from "./ReadingNoteListItem";
 
@@ -15,7 +16,7 @@ export function ReadingNoteListView({ notes }: ReadingNoteListViewProps) {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <div className={cn("flex flex-col", "lg:grid lg:grid-cols-2 lg:gap-4")}>
       {notes.map((note) => (
         <ReadingNoteListItem key={note.id} note={note} />
       ))}

--- a/src/modules/books/ui/view/__tests__/ReadingNoteListView.test.tsx
+++ b/src/modules/books/ui/view/__tests__/ReadingNoteListView.test.tsx
@@ -51,7 +51,7 @@ describe("ReadingNoteListView", () => {
     }
   });
 
-  it("グリッドレイアウトで表示される", () => {
+  it("レスポンシブな一覧レイアウトで表示される", () => {
     const notes = [
       {
         id: "1",
@@ -64,7 +64,7 @@ describe("ReadingNoteListView", () => {
 
     const { container } = render(<ReadingNoteListView notes={notes} />);
 
-    const grid = container.firstElementChild;
-    expect(grid).toHaveClass("grid");
+    const list = container.firstElementChild;
+    expect(list).toHaveClass("flex", "flex-col", "lg:grid", "lg:grid-cols-2");
   });
 });

--- a/src/modules/posts/ui/view/post-detail.tsx
+++ b/src/modules/posts/ui/view/post-detail.tsx
@@ -9,7 +9,7 @@ export type PostDetailViewProps = {
 
 export const PostDetailView: FC<PostDetailViewProps> = ({ post }) => {
   return (
-    <div className="content-wrapper @container/writing px-4 lg:py-20 lg:px-16">
+    <div className="content-wrapper @container/writing px-4 py-8 lg:py-20 lg:px-16">
       <article className="content">
         <PageTitle
           title={post.title}


### PR DESCRIPTION
- 読書メモ・日記ページにFloatingHeader/ScrollAreaを追加しレイアウト統一
- /booksページを一覧からトピック表示に変更（モバイル時縦並び）
- 読書メモ一覧をモバイルでリスト表示、デスクトップでグリッド表示に
- 詳細ページに戻るリンク付きヘッダーを追加
- 一覧・詳細ページのFloatingHeader下の余白を調整